### PR TITLE
Update slack api endpoints to remove depreciated channels.* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 - `channels:read`
 - `channels:manage`
+- `channels:history`
+- `channels:join`
 - `chat:write`
 - `groups:read`
 

--- a/slack_autoarchive.py
+++ b/slack_autoarchive.py
@@ -130,8 +130,6 @@ This script was run from a fork of this repo: https://github.com/Symantec/slack-
             if 'subtype' in message and message[
                     'subtype'] in self.settings.get('skip_subtypes'):
                 continue
-            if 'bot_id' in message: # is a bot message
-                continue
             last_message_datetime = datetime.fromtimestamp(float(
                 message['ts']))
             break
@@ -155,7 +153,6 @@ This script was run from a fork of this repo: https://github.com/Symantec/slack-
                                               payload=payload)
         (last_message_datetime, is_user) = self.get_last_message_timestamp(
             channel_history, datetime.fromtimestamp(float(channel['created'])))
-        print(last_message_datetime)
         # mark inactive if last message is too old, but don't
         # if there have been bot messages and the channel has
         # at least the minimum number of members


### PR DESCRIPTION
Slack has depreciated all of the channels.* methods to migrate to the conversation ones.

https://api.slack.com/methods/channels.history
https://api.slack.com/methods/channels.join
https://api.slack.com/methods/channels.list
https://api.slack.com/methods/channels.info
https://api.slack.com/methods/channels.archive

These methods are deprecated. They will stop functioning in February 2021 and will not work with newly created apps after June 10th, 2020.
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

https://api.slack.com/methods/conversations.history
https://api.slack.com/methods/conversations.join
https://api.slack.com/methods/conversations.list
https://api.slack.com/methods/conversations.info
https://api.slack.com/methods/conversations.archive
